### PR TITLE
DIV-2098-Migrate to strategic payment API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-pay-client",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Wrapper for payment-api calls",
   "license": "MIT",
   "main": "index.js",

--- a/src/create.js
+++ b/src/create.js
@@ -20,7 +20,8 @@ const logger = require('@hmcts/nodejs-logging').getLogger(__filename);
  * @returns {Promise} Request promise as returned by request-promise-native
  * @see https://tools.hmcts.net/confluence/display/RP/Payment+Reference+Standardisation
  */
-const create = (options = {}, user = {}, serviceToken = '', caseReference = '', siteId = 'AA00', feeCode = '', amount = 0, description = '', returnUrl = '') => {
+const create = (options = {}, user = {}, serviceToken = '', caseReference = '', siteId = 'AA00', feeCode = '',
+  feeVersion = 1, amount = 0, description = '', returnUrl = '') => {
   if (!serviceToken) {
     return Promise.reject(new Error('Service Authorization Token must be set'));
   }
@@ -34,16 +35,27 @@ const create = (options = {}, user = {}, serviceToken = '', caseReference = '', 
     logger.info('Default Site ID is being used.');
   }
 
-  const uri = `${options.apiBaseUrl}/users/${user.id}/payments`;
+  const uri = `${options.apiBaseUrl}/card-payments`;
+
   const body = {
     amount,
-    reference: `${options.serviceIdentification}$$$${caseReference}$$$${siteId}$$$${feeCode}`,
+    ccd_case_number: `${caseReference}`,
     description,
-    return_url: returnUrl
+    service: 'DIVORCE',
+    currency: 'GBP',
+    site_id: `${siteId}`,
+    fees: [
+      {
+        calculated_amount: amount,
+        code: feeCode,
+        version: feeVersion
+      }
+    ]
   };
   const headers = {
     Authorization: `Bearer ${user.bearerToken}`,
-    ServiceAuthorization: `Bearer ${serviceToken}`
+    ServiceAuthorization: `Bearer ${serviceToken}`,
+    'return-url': returnUrl
   };
 
   return request.post({ uri, body, headers, json: true });

--- a/src/create.js
+++ b/src/create.js
@@ -39,7 +39,7 @@ const create = (options = {}, user = {}, serviceToken = '', caseReference = '', 
 
   const body = {
     amount,
-    ccd_case_number: `${caseReference}`,
+    ccd_case_number: caseReference,
     description,
     service: 'DIVORCE',
     currency: 'GBP',

--- a/src/query.js
+++ b/src/query.js
@@ -13,16 +13,16 @@ const request = require('request-promise-native');
  *
  * @returns {Promise} Request promise as returned by request-promise-native
  */
-const query = (options = {}, user = {}, serviceToken = '', paymentId = '') => {
+const query = (options = {}, user = {}, serviceToken = '', reference = '') => {
   if (!serviceToken) {
     return Promise.reject(new Error('Service Authorization Token must be set'));
   }
-  if (!paymentId) {
-    return Promise.reject(new Error('Missing Payment ID'));
+  if (!reference) {
+    return Promise.reject(new Error('Missing Reference'));
   }
 
   return request.get({
-    uri: `${options.apiBaseUrl}/users/${user.id}/payments/${paymentId}`,
+    uri: `${options.apiBaseUrl}/card-payments/${reference}`,
     headers: {
       Authorization: `Bearer ${user.bearerToken}`,
       ServiceAuthorization: `Bearer ${serviceToken}`

--- a/test/pay-client.test.js
+++ b/test/pay-client.test.js
@@ -77,7 +77,7 @@ describe('payClient', () => {
         const { args } = request.post.getCall(0);
         expect(args[0].uri).to.equal(`${options.apiBaseUrl}/card-payments`);
         expect(args[0].body.amount).to.equal(amount);
-        expect(args[0].body.ccd_case_number).to.equal(`${caseReference}`);
+        expect(args[0].body.ccd_case_number).to.equal(caseReference);
         expect(args[0].body.description).to.equal(description);
         expect(args[0].body.fees[0].code).to.equal(feeCode);
         expect(args[0].body.fees[0].version).to.equal(feeVersion);

--- a/test/pay-client.test.js
+++ b/test/pay-client.test.js
@@ -44,7 +44,7 @@ describe('payClient', () => {
 
   describe('#create', () => {
     let user = {}, serviceToken = '', caseReference = '', siteId = '',
-      amount = 0, description = '', returnUrl = '', feeCode = '';
+      amount = 0, description = '', returnUrl = '', feeCode = '', feeVersion = '';
     const fiveThousand = 5000;
 
     beforeEach(() => {
@@ -56,13 +56,14 @@ describe('payClient', () => {
       description = 'description';
       returnUrl = 'https://return-url';
       feeCode = 'CODE';
+      feeVersion = 'VERSION';
     });
 
     context('Service token is not set', () => {
       it('rejects early', () => {
         // Act.
-        expect(client.create(user, undefined, caseReference, feeCode, amount,
-          description, returnUrl))
+        expect(client.create(user, undefined, caseReference, feeCode,
+          feeVersion, amount, description, returnUrl))
           .to.be.rejectedWith('Service Authorization Token must be set');
       });
     });
@@ -71,14 +72,16 @@ describe('payClient', () => {
       it('makes the request according to contract', () => {
         // Act.
         client.create(user, serviceToken, caseReference, siteId, feeCode,
-          amount, description, returnUrl);
+          feeVersion, amount, description, returnUrl);
         // Assert.
         const { args } = request.post.getCall(0);
-        expect(args[0].uri).to.equal(`${options.apiBaseUrl}/users/${user.id}/payments`);
+        expect(args[0].uri).to.equal(`${options.apiBaseUrl}/card-payments`);
         expect(args[0].body.amount).to.equal(amount);
-        expect(args[0].body.reference).to.equal(`${options.serviceIdentification}$$$${caseReference}$$$${siteId}$$$${feeCode}`);
+        expect(args[0].body.ccd_case_number).to.equal(`${caseReference}`);
         expect(args[0].body.description).to.equal(description);
-        expect(args[0].body.return_url).to.equal(returnUrl);
+        expect(args[0].body.fees[0].code).to.equal(feeCode);
+        expect(args[0].body.fees[0].version).to.equal(feeVersion);
+        expect(args[0].headers['return-url']).to.equal(returnUrl);
         expect(args[0].headers.Authorization).to.equal(`Bearer ${user.bearerToken}`);
         expect(args[0].headers.ServiceAuthorization).to.equal(`Bearer ${serviceToken}`);
       });
@@ -88,7 +91,7 @@ describe('payClient', () => {
       it('rejects early', () => {
         // Act.
         expect(client.create(user, serviceToken, undefined, siteId, feeCode,
-          amount, description, returnUrl))
+          feeVersion, amount, description, returnUrl))
           .to.be.rejectedWith('Case Reference not supplied, throwing error');
       });
     });
@@ -97,10 +100,10 @@ describe('payClient', () => {
       it('falls back to the default site ID', () => {
         // Act.
         client.create(user, serviceToken, caseReference, undefined, feeCode,
-          amount, description, returnUrl);
+          feeVersion, amount, description, returnUrl);
         // Assert.
         const { args } = request.post.getCall(0);
-        expect(args[0].body.reference).to.match(new RegExp(`^${options.serviceIdentification}\\$\\$\\$${caseReference}\\$\\$\\$AA00\\$\\$\\$${feeCode}$`));
+        expect(args[0].body.site_id).to.equal('AA00');
       });
     });
   });
@@ -136,7 +139,7 @@ describe('payClient', () => {
         client.query(user, serviceToken, paymentId);
         // Assert.
         const { args } = request.get.getCall(0);
-        expect(args[0].uri).to.equal(`${options.apiBaseUrl}/users/${user.id}/payments/${paymentId}`);
+        expect(args[0].uri).to.equal(`${options.apiBaseUrl}/card-payments/${paymentId}`);
         expect(args[0].headers.Authorization).to.equal(`Bearer ${user.bearerToken}`);
         expect(args[0].headers.ServiceAuthorization).to.equal(`Bearer ${options.serviceAuthorizationToken}`);
       });


### PR DESCRIPTION
Updated payment client with new ayment endpoint details

https://tools.hmcts.net/jira/browse/DIV-2098
This change points at the new payment API as specified in the following link.
https://tools.hmcts.net/confluence/display/RP/Payments+New+API+Changes#PaymentsNewAPIChanges-2.GetCardPaymentDetailsByPaymentReference

Unit tests changed as well.


