### PR TITLE
Bump Div Pay Client to 7.0.4, to match new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-pay-client",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Wrapper for payment-api calls",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
- Bump Div Pay Client to 7.0.4, to match new release